### PR TITLE
Add UI endpoints and React frontend

### DIFF
--- a/e2e_test.py
+++ b/e2e_test.py
@@ -1,0 +1,22 @@
+"""Simple script to exercise the new UI endpoints."""
+import requests
+
+BASE = "http://127.0.0.1:5000"
+
+
+def main():
+    s = requests.Session()
+    r = s.post(f"{BASE}/api/login", json={"username": "demo"})
+    print("login", r.status_code, r.json())
+
+    s.post(f"{BASE}/api/start-bot")
+    trades = s.get(f"{BASE}/api/open-trades").json()
+    print("open trades", trades)
+    s.post(f"{BASE}/api/stop-bot")
+    r = s.post(f"{BASE}/api/run-backtest", json={"pair": "BTC/USD"})
+    print("backtest", r.json())
+    print("results", s.get(f"{BASE}/api/backtest-results").json())
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Cherokee UI</title>
+    <link rel="stylesheet" href="src/index.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="src/index.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "cherokee-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test"
+  }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+import DynamicRenderer from './DynamicRenderer';
+
+export default function App() {
+  const [spec, setSpec] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/ui-spec').then(r => r.json()).then(setSpec);
+  }, []);
+
+  // theme: system preference
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const apply = () => {
+      document.body.dataset.theme = mq.matches ? 'dark' : 'light';
+    };
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, []);
+
+  if (!spec) return null;
+  return <DynamicRenderer spec={spec} />;
+}

--- a/frontend/src/DynamicRenderer.js
+++ b/frontend/src/DynamicRenderer.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+
+function ComponentFactory({ comp }) {
+  switch (comp.type) {
+    case 'TextInput':
+      return <input placeholder={comp.placeholder} name={comp.bind || comp.id} />;
+    case 'PasswordInput':
+      return <input type="password" placeholder={comp.placeholder} name={comp.bind || comp.id} />;
+    case 'Button':
+      return <button>{comp.text}</button>;
+    case 'Select':
+    case 'Dropdown':
+      return <select><option>{comp.placeholder}</option></select>;
+    case 'Switch':
+      return <label><input type="checkbox" /> {comp.label}</label>;
+    case 'DatePicker':
+      return <input type="date" />;
+    case 'Chart':
+      return <div className="chart-placeholder">{comp.id}</div>;
+    case 'Table':
+      return (
+        <table>
+          <thead>
+            <tr>{comp.columns.map(c => <th key={c}>{c}</th>)}</tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      );
+    case 'IconButton':
+      return <button>{comp.icon}</button>;
+    default:
+      return null;
+  }
+}
+
+function Page({ section }) {
+  return (
+    <div className="page" id={section.id}>
+      {section.components && section.components.map(c => (
+        <ComponentFactory key={c.id} comp={c} />
+      ))}
+    </div>
+  );
+}
+
+export default function DynamicRenderer({ spec }) {
+  const pages = spec.sections.filter(s => s.type === 'page');
+  return (
+    <Router>
+      <nav>
+        {pages.map(p => <Link key={p.id} to={`/${p.id}`}>{p.id}</Link>)}
+      </nav>
+      <Routes>
+        {pages.map(p => <Route key={p.id} path={`/${p.id}`} element={<Page section={p} />} />)}
+        <Route path="*" element={<div>Home</div>} />
+      </Routes>
+    </Router>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,23 @@
+body[data-theme='dark'] {
+  background: #111;
+  color: #eee;
+}
+body[data-theme='light'] {
+  background: #fff;
+  color: #000;
+}
+
+.page {
+  padding: 1rem;
+}
+
+nav a {
+  margin-right: 1rem;
+}
+
+.chart-placeholder {
+  width: 100%;
+  height: 200px;
+  background: #ccc;
+  margin: 1rem 0;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai
 sqlalchemy
 pytest
 pytest-asyncio
+requests

--- a/tests/test_ui_endpoints.py
+++ b/tests/test_ui_endpoints.py
@@ -1,0 +1,51 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cherokee import database
+from cherokee.web import create_app
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_url = f"sqlite:///{tmp_path}/ui.db"
+    engine = create_engine(db_url)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(database, "engine", engine)
+    monkeypatch.setattr(database, "SessionLocal", Session)
+    monkeypatch.setenv("CHEROKEE_AUTO_SAMPLE", "0")
+    from cherokee.web import api as api_module
+    from cherokee import trading as trading_module
+    monkeypatch.setattr(api_module, "SessionLocal", Session, raising=False)
+    monkeypatch.setattr(trading_module, "SessionLocal", Session, raising=False)
+    database.init_db()
+    app = create_app()
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_ui_spec(client):
+    resp = client.get("/api/ui-spec")
+    assert resp.status_code == 200
+    assert "sections" in resp.get_json()
+
+
+def test_login_and_bot(client):
+    resp = client.post("/api/login", json={"username": "u", "password": "p"})
+    assert resp.status_code == 200
+    token = resp.get_json().get("token")
+    assert token
+
+    resp = client.post("/api/start-bot")
+    assert resp.status_code == 200
+    assert resp.get_json()["running"] is True
+
+    resp = client.post("/api/stop-bot")
+    assert resp.status_code == 200
+    assert resp.get_json()["running"] is False
+
+
+def test_open_trades_empty(client):
+    resp = client.get("/api/open-trades")
+    assert resp.status_code == 200
+    assert resp.get_json() == []


### PR DESCRIPTION
## Summary
- implement new endpoints `/ui-spec`, login, bot control, settings, and backtesting
- add placeholder React frontend that builds UI from `design.json`
- create end-to-end test script and tests for new endpoints
- update requirements with `requests`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617fff3ac08320a4fec166f078f058