### PR TITLE
Add Scalper module and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,16 @@ The app consumes the JSON specification in `logic_playground.json` and exposes t
 - `POST /api/logic/deploy` – deploy the graph
 
 Marketplace endpoints allow saving and retrieving personalities and workflows.
+
+## Scalper Module
+
+The Scalper feature exposes a new set of API endpoints for building and deploying scalping strategies.
+
+- `GET /api/scalper/spec` – return the `scalper.json` specification used by the UI
+- `GET /api/scalper/feed` – live feed of trending tokens (stub data)
+- `GET /api/scalper/sentiment?token=SYMBOL` – placeholder sentiment lookup
+- `POST /api/scalper/deploy` – deploy a strategy JSON and store it under `scalper_strategies/`
+- `POST /api/scalper/stop` – stop a running strategy by `id`
+- `GET /api/scalper/monitor` – list currently active strategies
+
+Strategies are saved as JSON files in the `scalper_strategies/` directory.

--- a/cherokee/scalper/__init__.py
+++ b/cherokee/scalper/__init__.py
@@ -1,0 +1,1 @@
+from .api import bp

--- a/cherokee/scalper/api.py
+++ b/cherokee/scalper/api.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, Any
+
+from flask import Blueprint, request, jsonify
+
+bp = Blueprint("scalper", __name__, url_prefix="/api/scalper")
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC_PATH = ROOT / "scalper.json"
+STRATEGY_DIR = Path(os.getenv("SCALPER_STRATEGY_DIR", ROOT / "scalper_strategies"))
+STRATEGY_DIR.mkdir(exist_ok=True)
+
+# in-memory registry of deployed strategies for this process
+_active: Dict[str, Dict[str, Any]] = {}
+
+
+@bp.get("/spec")
+def scalper_spec():
+    """Return the canonical scalper JSON specification."""
+    with open(SPEC_PATH, "r") as f:
+        data = json.load(f)
+    return jsonify(data)
+
+
+@bp.get("/feed")
+def scalper_feed():
+    """Placeholder endpoint returning trending token data."""
+    sample = [
+        {"token": "SAMPLE", "price": 1.0, "volume24h": 1000, "hypeScore": 0.5, "newListing": False, "alerts": []}
+    ]
+    return jsonify(sample)
+
+
+@bp.get("/sentiment")
+def sentiment():
+    """Return placeholder sentiment information for a token."""
+    token = request.args.get("token", "SAMPLE")
+    return jsonify({"token": token, "sentiment": 0.0})
+
+
+@bp.post("/deploy")
+def deploy_strategy():
+    """Save and activate a scalper strategy."""
+    data = request.get_json() or {}
+    sid = data.get("id") or f"strategy_{len(_active)+1}"
+    if not data.get("modules"):
+        return jsonify({"error": "missing modules"}), 400
+    path = STRATEGY_DIR / f"{sid}.json"
+    with open(path, "w") as f:
+        json.dump(data, f)
+    _active[sid] = data
+    return jsonify({"status": "deployed", "id": sid})
+
+
+@bp.post("/stop")
+def stop_strategy():
+    sid = request.get_json(silent=True) or {}
+    sid = sid.get("id")
+    if sid and sid in _active:
+        _active.pop(sid)
+        return jsonify({"status": "stopped", "id": sid})
+    return jsonify({"error": "not found"}), 404
+
+
+@bp.get("/monitor")
+def monitor():
+    """Return list of active strategy ids."""
+    return jsonify({"active": list(_active.keys())})

--- a/cherokee/web/__init__.py
+++ b/cherokee/web/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify
 from flask_cors import CORS
 from .api import bp
 from ..logic_playground.api import bp as logic_bp
+from ..scalper import bp as scalper_bp
 from ..database import init_db, populate_sample_data
 import os
 
@@ -10,6 +11,7 @@ def create_app():
     CORS(app)
     init_db()
     app.register_blueprint(logic_bp)
+    app.register_blueprint(scalper_bp)
     if os.getenv("CHEROKEE_AUTO_SAMPLE", "1") == "1" and not app.config.get("TESTING"):
         populate_sample_data()
     app.register_blueprint(bp)

--- a/tests/test_scalper.py
+++ b/tests/test_scalper.py
@@ -1,0 +1,49 @@
+import json
+import os
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cherokee import database
+from cherokee.web import create_app
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_url = f"sqlite:///{tmp_path}/scalper.db"
+    engine = create_engine(db_url)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(database, "engine", engine)
+    monkeypatch.setattr(database, "SessionLocal", Session)
+    monkeypatch.setenv("CHEROKEE_AUTO_SAMPLE", "0")
+    monkeypatch.setenv("SCALPER_STRATEGY_DIR", str(tmp_path / "strategies"))
+    from cherokee.web import api as api_module
+    from cherokee.logic_playground import api as logic_api
+    monkeypatch.setattr(api_module, "SessionLocal", Session, raising=False)
+    monkeypatch.setattr(logic_api, "SessionLocal", Session, raising=False)
+    database.init_db()
+    app = create_app()
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_scalper_spec(client):
+    resp = client.get("/api/scalper/spec")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["id"] == "ScalperModuleV1"
+
+
+def test_deploy_and_monitor_strategy(client, tmp_path):
+    strategy = {"id": "demo", "modules": ["a"]}
+    resp = client.post("/api/scalper/deploy", json=strategy)
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "deployed"
+
+    resp = client.get("/api/scalper/monitor")
+    assert resp.status_code == 200
+    assert "demo" in resp.get_json()["active"]
+
+    resp = client.post("/api/scalper/stop", json={"id": "demo"})
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "stopped"


### PR DESCRIPTION
## Summary
- implement scalper blueprint with endpoints (`/api/scalper/...`)
- register blueprint in the Flask app
- document scalper endpoints in the README
- add directory for saved strategies
- include tests for new scalper endpoints

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686193d2775c8320a2fb6cec33319a9d