### PR TITLE
Improve startup and service supervision

### DIFF
--- a/cherokee/server.py
+++ b/cherokee/server.py
@@ -1,6 +1,17 @@
+"""Entry point for running the Cherokee Flask API."""
+
+import os
+
 from .web import create_app
 
 app = create_app()
 
-if __name__ == '__main__':
-    app.run(debug=True)
+
+def run() -> None:
+    """Run the Flask app with sane defaults for start_services.sh."""
+    debug = os.getenv("CHEROKEE_DEBUG", "0") == "1"
+    app.run(host="127.0.0.1", port=5000, debug=debug, use_reloader=False)
+
+
+if __name__ == "__main__":
+    run()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.14.1"
+    "react-router-dom": "^6.14.1",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/start_services.sh
+++ b/start_services.sh
@@ -8,7 +8,7 @@ run_with_restart() {
   local log="$2"
   while true; do
     echo "Starting $cmd" | tee -a "$log"
-    eval "$cmd" >> "$log" 2>&1 &
+    bash -c "$cmd" >> "$log" 2>&1 &
     pid=$!
     wait $pid && exit_code=$? || exit_code=$?
     echo "$(date) - $cmd exited with $exit_code" | tee -a "$log"
@@ -17,16 +17,28 @@ run_with_restart() {
   echo $!
 }
 
+if [ ! -d "frontend/node_modules" ] || [ ! -f "frontend/node_modules/.bin/react-scripts" ]; then
+  echo "Installing frontend dependencies..."
+  npm --prefix frontend install --no-audit --no-fund >> "$LOG_DIR/frontend.log" 2>&1
+fi
+
 UI_WATCH=$(run_with_restart "npm --prefix frontend start" "$LOG_DIR/frontend.log")
 SERVER_WATCH=$(run_with_restart "python -m cherokee.server" "$LOG_DIR/server.log")
 
 # wait for backend health
+API_HEALTH=0
 for i in {1..20}; do
   if curl -s http://127.0.0.1:5000/api/healthz >/dev/null 2>&1; then
+    API_HEALTH=1
     break
   fi
   sleep 1
 done
+if [ "$API_HEALTH" -ne 1 ]; then
+  echo "Backend failed to become healthy" | tee -a "$LOG_DIR/server.log"
+  kill "$UI_WATCH" "$SERVER_WATCH" >/dev/null 2>&1 || true
+  exit 1
+fi
 
 SCANNER_WATCH=$(run_with_restart "python -m cherokee.run_scanner" "$LOG_DIR/scanner.log")
 


### PR DESCRIPTION
## Summary
- improve startup supervision script
- install frontend deps on demand and check API health
- disable Flask reloader and make debug flag optional
- include `react-scripts` in frontend deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a1c464048320adf25e99d4e61f97