### PR TITLE
Improve start script for reliable environment setup

### DIFF
--- a/start_services.sh
+++ b/start_services.sh
@@ -3,6 +3,21 @@ set -euo pipefail
 LOG_DIR="logs"
 mkdir -p "$LOG_DIR"
 
+# ensure a virtual environment exists and activate it
+PYTHON=${PYTHON:-python3}
+if [ ! -f ".venv/bin/activate" ]; then
+  echo "Creating virtual environment..." | tee -a "$LOG_DIR/pip.log"
+  rm -rf .venv
+  "$PYTHON" -m venv .venv >> "$LOG_DIR/pip.log" 2>&1
+fi
+source .venv/bin/activate
+
+# install Python dependencies if needed
+if ! pip show flask >/dev/null 2>&1; then
+  echo "Installing Python dependencies..." | tee -a "$LOG_DIR/pip.log"
+  pip install -r requirements.txt >> "$LOG_DIR/pip.log" 2>&1
+fi
+
 run_with_restart() {
   local cmd="$1"
   local log="$2"
@@ -18,12 +33,12 @@ run_with_restart() {
 }
 
 if [ ! -d "frontend/node_modules" ] || [ ! -f "frontend/node_modules/.bin/react-scripts" ]; then
-  echo "Installing frontend dependencies..."
+  echo "Installing frontend dependencies..." | tee -a "$LOG_DIR/frontend.log"
   npm --prefix frontend install --no-audit --no-fund >> "$LOG_DIR/frontend.log" 2>&1
 fi
 
 UI_WATCH=$(run_with_restart "npm --prefix frontend start" "$LOG_DIR/frontend.log")
-SERVER_WATCH=$(run_with_restart "python -m cherokee.server" "$LOG_DIR/server.log")
+SERVER_WATCH=$(run_with_restart "$PYTHON -m cherokee.server" "$LOG_DIR/server.log")
 
 # wait for backend health
 API_HEALTH=0
@@ -40,7 +55,7 @@ if [ "$API_HEALTH" -ne 1 ]; then
   exit 1
 fi
 
-SCANNER_WATCH=$(run_with_restart "python -m cherokee.run_scanner" "$LOG_DIR/scanner.log")
+SCANNER_WATCH=$(run_with_restart "$PYTHON -m cherokee.run_scanner" "$LOG_DIR/scanner.log")
 
 trap "kill $UI_WATCH $SERVER_WATCH $SCANNER_WATCH" EXIT INT TERM
 wait


### PR DESCRIPTION
## Summary
- add virtualenv creation and Python dependency checks to `start_services.sh`
- log frontend dependency installation
- use selected Python interpreter for server and scanner processes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b410e26083208d890e998f9464d2